### PR TITLE
fix: migrate train.yml to Ruff only (ADR-016 compliance)

### DIFF
--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -1,6 +1,7 @@
 # .github/workflows/train.yml
 # CI pipeline: lint, test, and optional training proof
 # Triggers on push and pull_request to main
+# ADR-016: Modern Python Code Quality (Ruff only)
 
 name: CI
 
@@ -9,39 +10,39 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
+# 2026 Best Practice: Smart concurrency
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:
-    name: Lint
+    name: Lint (Ruff)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
           cache: pip
           cache-dependency-path: requirements*.txt
 
       - name: Install lint dependencies
         run: |
-          pip install ruff black flake8
+          pip install --upgrade pip
+          pip install ruff
 
-      - name: Run ruff
+      - name: Run ruff format check
+        run: ruff format --check .
+
+      - name: Run ruff lint
         run: ruff check .
-
-      - name: Check black formatting
-        run: black --check .
-
-      - name: Run flake8
-        run: flake8 . --max-line-length=88 --extend-ignore=E203,W503
 
   test:
     name: Tests

--- a/plans/ADR-016-modern-python-code-quality-2026.md
+++ b/plans/ADR-016-modern-python-code-quality-2026.md
@@ -1,7 +1,7 @@
 # ADR-016: Modern Python Code Quality Setup for 2026
 
 **Date:** 2026-02-24
-**Status:** Proposed
+**Status:** Implemented
 **Authors:** AI Agent
 **Related:** ADR-014 (Quality Gate CI Alignment), ADR-015 (GitHub Workflow Caching)
 

--- a/plans/GOAP.md
+++ b/plans/GOAP.md
@@ -156,6 +156,7 @@ Build a cats classifier and generator with web frontend, following the architect
 - ✅ Verified `.github/workflows/deploy.yml` for GitHub Pages deployment
 - ✅ Updated ADR-013 status to "Implemented"
 - ✅ All workflows follow 2026 best practices (concurrency, dispatch, names)
+- ✅ Fixed `train.yml` to use Ruff only (ADR-016 compliance)
 
 ### Remaining Work
 - **Phase 3: Modal Training** - Execute full TinyDiT training (200k steps, EMA)
@@ -172,9 +173,9 @@ Build a cats classifier and generator with web frontend, following the architect
 | Model size | <100MB | ✅ 11MB (quantized) |
 | Inference | <2s generation | ✅ Benchmark page ready |
 | Frontend | Responsive UI | ✅ Complete |
-| CI | All checks pass | ✅ All 5 jobs passing |
+| CI | All checks pass | ✅ All 5 jobs passing (Ruff only) |
 | Quality Gate | Local = CI | ✅ ADR-014 implemented |
-| Code Quality | 2026 stack | ✅ ADR-016 (Ruff) |
+| Code Quality | 2026 stack | ✅ ADR-016 (Ruff) - All workflows migrated |
 | Training Infrastructure | 200k steps with EMA | ✅ ADR-017 (Ready to run) |
 
 ## Success Metrics


### PR DESCRIPTION
This PR fixes the train.yml workflow to use Ruff only, consistent with ADR-016.

## Changes
- Replace black+flake8 with ruff format and ruff check
- Update concurrency pattern to match ci.yml best practices
- Update ADR-016 status to Implemented
- Update GOAP.md with completed Ruff migration

## Testing
- Quality gate passes locally (ruff format, ruff check, mypy, pytest)
- All workflows use consistent Ruff-only linting

## Related
- ADR-016: Modern Python Code Quality Setup for 2026
- GOAP.md Phase 6: Documentation & CI/CD