### PR TITLE
docs: adopt Modal CLI-first training strategy (ADR-020)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ AI agent guidance for tiny-cats-model (cat image classification with DiT).
 - Type hints required for new code
 - Format: `ruff format .`
 - Lint: `ruff check . --fix`
+- 500 LOC max per file
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,11 @@ AI agent guidance for the tiny-cats-model project.
 |------|---------|
 | Install | `pip install -r requirements.txt` |
 | Download data | `bash data/download.sh` |
-| Train (Modal GPU) | `modal run src/train.py` |
-| Train (local) | `python src/train.py data/cats` |
-| Train options | `modal run src/train.py -- --epochs 20 --batch-size 64` |
+| **Train Classifier (Modal GPU)** | `modal run src/train.py data/cats` |
+| **Train DiT (Modal GPU)** | `modal run src/train_dit.py data/cats` |
+| Train options (classifier) | `modal run src/train.py -- --epochs 20 --batch-size 64` |
+| Train options (DiT) | `modal run src/train_dit.py -- --steps 200000 --batch-size 256` |
+| Train (local CPU) | `python src/train.py data/cats` |
 | Evaluate | `python src/eval.py` |
 | **Quality gate** | `bash scripts/quality-gate.sh` (ruff format + ruff check) |
 | **Pre-commit** | `pre-commit install && pre-commit run --all-files` |
@@ -19,6 +21,8 @@ AI agent guidance for the tiny-cats-model project.
 | Lint | `ruff check . && ruff format --check .` |
 | Format | `ruff format .` |
 | **CI Monitor** | `gh run list && gh run view <id>` |
+
+> **Note:** See ADR-020 for complete Modal CLI reference.
 
 ## Code Style
 
@@ -90,7 +94,7 @@ See [agents-docs/security.md](agents-docs/security.md) for details.
 
 ```
 tiny-cats-model/
-├── src/              # train.py, eval.py, model.py, dataset.py
+├── src/              # train.py, train_dit.py, eval.py, model.py, dataset.py
 ├── tests/            # test_dataset.py, test_model.py, test_train.py
 ├── data/cats/        # dataset (gitignored)
 ├── .agents/skills/   # agent automation
@@ -98,17 +102,39 @@ tiny-cats-model/
 ├── plans/            # GOAP, ADR documents
 ├── agents-docs/      # Extended agent documentation
 ├── AGENTS.md         # this file
-└── modal.yml         # GPU training config
+└── modal.yml         # Modal CLI reference (documentation only, see ADR-020)
 ```
 
 ## Modal GPU Training
 
 Modal tokens configured globally via `modal token set`.
 
+**See ADR-020 for the complete Modal CLI-First Training Strategy.**
+
+### Classifier Training
+
 ```bash
-modal run src/train.py
-modal run src/train.py -- --epochs 20 --batch-size 64
-python src/train.py data/cats  # local CPU
+# Modal GPU training (recommended)
+modal run src/train.py data/cats
+
+# With options
+modal run src/train.py -- --epochs 20 --batch-size 64 --backbone resnet34
+
+# Local CPU testing (debug)
+python src/train.py data/cats --epochs 1 --batch-size 8
+```
+
+### DiT Training
+
+```bash
+# Modal GPU training (recommended)
+modal run src/train_dit.py data/cats
+
+# With options
+modal run src/train_dit.py -- --steps 200000 --batch-size 256 --lr 0.0001
+
+# Local CPU testing (debug)
+python src/train_dit.py data/cats --steps 100 --batch-size 8
 ```
 
 See [agents-docs/training.md](agents-docs/training.md) for full options.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,164 +1,50 @@
-# tiny-cats-model AGENTS.md
+# AGENTS.md
 
-AI agent guidance for the tiny-cats-model project.
+AI agent guidance for tiny-cats-model (cat image classification with DiT).
 
-## Quick Commands
+## Setup
 
-| Task | Command |
-|------|---------|
-| Install | `pip install -r requirements.txt` |
-| Download data | `bash data/download.sh` |
-| **Train Classifier (Modal GPU)** | `modal run src/train.py data/cats` |
-| **Train DiT (Modal GPU)** | `modal run src/train_dit.py data/cats` |
-| Train options (classifier) | `modal run src/train.py -- --epochs 20 --batch-size 64` |
-| Train options (DiT) | `modal run src/train_dit.py -- --steps 200000 --batch-size 256` |
-| Train (local CPU) | `python src/train.py data/cats` |
-| Evaluate | `python src/eval.py` |
-| **Quality gate** | `bash scripts/quality-gate.sh` (ruff format + ruff check) |
-| **Pre-commit** | `pre-commit install && pre-commit run --all-files` |
-| Verify | `bash .agents/skills/git-workflow/quality-gate.sh` |
-| Tests | `pytest tests/ -v` |
-| Lint | `ruff check . && ruff format --check .` |
-| Format | `ruff format .` |
-| **CI Monitor** | `gh run list && gh run view <id>` |
+- Install deps: `pip install -r requirements.txt`
+- Download data: `bash data/download.sh`
 
-> **Note:** See ADR-020 for complete Modal CLI reference.
+## Build & Run
+
+- Train classifier (Modal GPU): `modal run src/train.py data/cats`
+- Train DiT (Modal GPU): `modal run src/train_dit.py data/cats`
+- Train local (CPU debug): `python src/train.py data/cats --epochs 1 --batch-size 8`
+- Evaluate: `python src/eval.py`
 
 ## Code Style
 
-- **PEP 8** - Python standard
-- **Line length**: 88 chars
-- **Linting**: `ruff check . --fix` (Ruff replaces flake8, isort, black)
-- **Formatting**: `ruff format .`
-- **Type hints**: Required for new code
-- **500 LOC max per file**
+- PEP 8 with Ruff
+- Line length: 88 chars
+- Type hints required for new code
+- Format: `ruff format .`
+- Lint: `ruff check . --fix`
 
-## What NOT to Do
+## Testing
 
-- Never hardcode tokens or secrets
-- Never commit `.env` files
-- Never skip CI checks before merging
-- Never use `--force` with git push to main
-- Never commit without running quality gate locally: `bash scripts/quality-gate.sh`
-- Never merge if local quality gate passes but CI fails (report config mismatch)
-
-## Agent Skills
-
-See [agents-docs/skills.md](agents-docs/skills.md) for full details.
-
-| Skill | When to Use |
-|-------|-------------|
-| `analysis-swarm` | Complex decisions, multi-perspective analysis |
-| `cli-usage` | Training, evaluation, dataset |
-| `testing-workflow` | Running tests, verification |
-| `code-quality` | Linting, formatting |
-| `gh-actions` | CI/CD, workflows |
-| `git-workflow` | Branches, commits, PRs |
-| `goap` | Planning, ADR, project goals |
-| `security` | Secrets, credentials |
-| `model-training` | GPU training, Modal |
-| `web-search-researcher` | Web research, documentation lookup |
-
-## CI/CD
-
-- **Workflows**: `.github/workflows/ci.yml`, `train.yml`, `deploy.yml`
-- **Trigger**: push + PR to `main` + `workflow_dispatch`
-- **Jobs**: lint → test → type-check → build-frontend
-- **Never merge if CI fails**
-
-### Quality Gate Parity (ADR-014)
-
-The local quality gate runs the **same checks** as CI:
-
-```bash
-bash scripts/quality-gate.sh
-```
-
-This ensures: **what passes locally passes in CI**.
-
-**Configuration Files**:
-- `ruff.toml` - Ruff config (single source of truth for linting + formatting)
-- `pyproject.toml` - Mypy config
-
-See [agents-docs/ci-cd.md](agents-docs/ci-cd.md) for fix workflows and CLI commands.
+- Run tests: `pytest tests/ -v`
+- Quality gate (lint + format + test): `bash scripts/quality-gate.sh`
+- Pre-commit hooks: `pre-commit install && pre-commit run --all-files`
 
 ## Security
 
-- **Never hardcode tokens** - Use env vars
-- **Never commit `.env`** - Already gitignored
-- **Modal tokens**: Configured globally via `modal token set`
+- Never hardcode tokens or secrets
+- Never commit `.env` files
+- Use environment variables for credentials
+- Modal tokens: configured globally via `modal token set`
 
-See [agents-docs/security.md](agents-docs/security.md) for details.
+## PR Instructions
 
-## File Structure
+- Run quality gate before committing: `bash scripts/quality-gate.sh`
+- Never skip CI checks before merging
+- Never merge if CI fails
 
-```
-tiny-cats-model/
-├── src/              # train.py, train_dit.py, eval.py, model.py, dataset.py
-├── tests/            # test_dataset.py, test_model.py, test_train.py
-├── data/cats/        # dataset (gitignored)
-├── .agents/skills/   # agent automation
-├── .github/workflows/
-├── plans/            # GOAP, ADR documents
-├── agents-docs/      # Extended agent documentation
-├── AGENTS.md         # this file
-└── modal.yml         # Modal CLI reference (documentation only, see ADR-020)
-```
+## Extended Docs
 
-## Modal GPU Training
-
-Modal tokens configured globally via `modal token set`.
-
-**See ADR-020 for the complete Modal CLI-First Training Strategy.**
-
-### Classifier Training
-
-```bash
-# Modal GPU training (recommended)
-modal run src/train.py data/cats
-
-# With options
-modal run src/train.py -- --epochs 20 --batch-size 64 --backbone resnet34
-
-# Local CPU testing (debug)
-python src/train.py data/cats --epochs 1 --batch-size 8
-```
-
-### DiT Training
-
-```bash
-# Modal GPU training (recommended)
-modal run src/train_dit.py data/cats
-
-# With options
-modal run src/train_dit.py -- --steps 200000 --batch-size 256 --lr 0.0001
-
-# Local CPU testing (debug)
-python src/train_dit.py data/cats --steps 100 --batch-size 8
-```
-
-See [agents-docs/training.md](agents-docs/training.md) for full options.
-
-## Notes
-
-- Run `bash scripts/quality-gate.sh` before every commit (runs all CI checks locally)
-- Dataset `data/cats/` and `cats_model.pt` are gitignored
-- Max workflow timeout: 10 minutes
-- Always use type hints for new functions
-- Ruff line-length: 88 chars (matches CI)
-
-## Learnings & Patterns
-
-See [agents-docs/learnings.md](agents-docs/learnings.md) for self-learning loop, key learnings, and reusable patterns.
-
-## Automation Scripts
-
-| Script | Purpose |
-|--------|---------|
-| `python scripts/update-learnings.py` | Auto-update learnings.md |
-| `python scripts/adr-scaffold.py "Title"` | Create new ADR |
-| `python scripts/update-goap.py` | Update GOAP action items |
-| `bash scripts/quality-gate.sh` | Run format, lint, test |
-
-Install hooks: `bash scripts/install-hooks.sh`
-See [scripts/README.md](scripts/README.md) for details.
+- [Training detailed options](agents-docs/training.md)
+- [CI/CD workflows & debugging](agents-docs/ci-cd.md)
+- [Security best practices](agents-docs/security.md)
+- [Agent skills reference](agents-docs/skills.md)
+- [Learnings & patterns](agents-docs/learnings.md)

--- a/modal.yml
+++ b/modal.yml
@@ -1,57 +1,106 @@
-# modal.yml
-# Modal configuration for GPU-accelerated training.
-# See: https://modal.com/docs
+# modal.yml - DOCUMENTATION REFERENCE ONLY
 #
-# IMPORTANT: Never hardcode secrets here.
-# Provide credentials via environment variables:
-#   export MODAL_TOKEN_ID=<your_token_id>
-#   export MODAL_TOKEN_SECRET=<your_token_secret>
+# ⚠️  IMPORTANT: This file is NOT executed directly by Modal.
 #
-# Usage:
-#   modal run src/train.py
-
-build:
-  python: "3.10"
-  apt_packages:
-    - wget
-    - unzip
-  requirements:
-    - torch>=2.0.0
-    - torchvision>=0.15.0
-    - pillow>=9.0.0
-    - tqdm>=4.65.0
+# This file serves as a quick reference for Modal CLI commands and configuration.
+# All training should use the Modal CLI with Python scripts directly.
+#
+# See ADR-020 for full details on the Modal CLI-First Training Strategy.
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# QUICK REFERENCE
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Authentication (one-time setup):
+#   modal token set
+#
+# Classifier Training:
+#   modal run src/train.py data/cats                    # Default settings
+#   modal run src/train.py data/cats -- --epochs 20     # Custom epochs
+#   modal run src/train.py -- --epochs 20 --batch-size 64 --backbone resnet34
+#
+# DiT Training:
+#   modal run src/train_dit.py data/cats                # Default settings
+#   modal run src/train_dit.py -- --steps 200000        # Custom steps
+#   modal run src/train_dit.py -- --steps 200000 --batch-size 256 --lr 0.0001
+#
+# Local Testing (CPU):
+#   python src/train.py data/cats --epochs 1 --batch-size 8
+#   python src/train_dit.py data/cats --steps 100 --batch-size 8
+#
+# Volume Management:
+#   modal volume ls cats-model-outputs                  # List outputs
+#   modal volume get cats-model-outputs /outputs/model.pt ./model.pt
+#
+# Monitoring:
+#   modal app list                                      # List apps
+#   modal app logs tiny-cats-model                      # View logs
+#
+# ═══════════════════════════════════════════════════════════════════════════════
+# CONFIGURATION REFERENCE (Implemented in Python Scripts)
+# ═══════════════════════════════════════════════════════════════════════════════
 
 app:
   name: tiny-cats-model
-  image: pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
+  # Configured in: src/train.py, src/train_dit.py
+  # via: app = modal.App("tiny-cats-model")
 
-training:
-  # GPU type: use gpu-t4 for cost-efficiency, gpu-a10g for speed
-  gpu: gpu-t4
-  timeout: 3600  # 1 hour max
-  retries: 1
+image:
+  base: pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
+  python: "3.10"
+  # Configured in: @app.function(image=...)
+  # Dependencies: torch, torchvision, pillow, tqdm (via pip_install)
 
-  entrypoint: "python src/train.py data/cats --epochs 20 --backbone resnet18"
+gpu:
+  # GPU type: use "T4" for cost-efficiency, "A10G" for speed
+  # Configured in: @app.function(gpu="T4")
+  type: T4
+  alternatives:
+    - T4     # ~$0.35/hr, good for standard training
+    - A10G   # ~$1.00/hr, faster training
+    - A100   # ~$3.00/hr, large-scale training
 
-  # Environment variables (values injected at runtime, NOT stored here)
-  env:
-    MODAL_TOKEN_ID: ""       # Set via: export MODAL_TOKEN_ID=...
-    MODAL_TOKEN_SECRET: ""   # Set via: export MODAL_TOKEN_SECRET=...
-    DATA_DIR: "data/cats"
-    OUTPUT_PATH: "cats_model.pt"
+timeout: 7200  # 2 hours max (configured in @app.function(timeout=7200))
 
-  # Mount local source code
-  mounts:
-    - local_dir: "."
-      remote_path: "/root/tiny-cats-model"
-
+volumes:
   # Volume for storing trained model checkpoints
-  volumes:
-    - name: cats-model-outputs
-      mount_path: /outputs
+  - name: cats-model-outputs
+    mount_path: /outputs
+  # Volume for dataset (optional, can download at runtime)
+  - name: cats-dataset
+    mount_path: /data
+
+environment:
+  # Environment variables (values injected at runtime via Modal secrets)
+  # Never store actual secrets in this file
+  DATA_DIR: "data/cats"
+  OUTPUT_PATH: "cats_model.pt"
+  # MODAL_TOKEN_ID: Set via `modal token set`
+  # MODAL_TOKEN_SECRET: Set via `modal token set`
 
 dataset:
   # Dataset can be downloaded inside Modal via data/download.sh
   # or pre-uploaded to a Modal volume
   prepare_cmd: "bash data/download.sh"
-  data_dir: "/root/tiny-cats-model/data/cats"
+  data_dir: "/data/cats"
+
+training:
+  # Default training entrypoints
+  classifier: "python src/train.py data/cats --epochs 20 --backbone resnet18"
+  dit: "python src/train_dit.py data/cats --steps 200000 --batch-size 256"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# RELATED DOCUMENTATION
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# ADR-020: Modal CLI-First Training Strategy (this file's rationale)
+# ADR-007: Modal GPU Training Fix
+# ADR-010: Modal Training Improvements
+# ADR-017: TinyDiT Training Infrastructure
+#
+# Modal Documentation:
+#   https://modal.com/docs
+#   https://modal.com/docs/guide/gpu
+#   https://modal.com/docs/reference/cli
+#
+# ═══════════════════════════════════════════════════════════════════════════════

--- a/plans/ADR-010-modal-training-improvements.md
+++ b/plans/ADR-010-modal-training-improvements.md
@@ -1,10 +1,10 @@
 # ADR-010: Modal Training Improvements - Error Handling, Logging, Performance, and Memory Management
 
 ## Status
-Proposed
+Implemented
 
 ## Date
-2026-02-24
+2026-02-24 (Proposed) | 2026-02-25 (Implemented)
 
 ## Context
 The current Modal training setup in `src/train.py` works but lacks production-ready features:
@@ -49,6 +49,28 @@ We will implement comprehensive improvements to the training pipeline:
 - **Memory Monitoring**: Log GPU memory usage during training
 
 ## Implementation Plan
+
+### Scripts Implemented
+
+The improvements from this ADR are now implemented in:
+- **`src/train.py`** - ResNet classifier training with all improvements
+- **`src/train_dit.py`** - TinyDiT training with flow matching and EMA
+
+### Usage (Modal CLI)
+
+```bash
+# Classifier training (Modal GPU)
+modal run src/train.py data/cats --epochs 20 --batch-size 64
+
+# DiT training (Modal GPU)
+modal run src/train_dit.py data/cats --steps 200000 --batch-size 256
+
+# Local testing (CPU)
+python src/train.py data/cats --epochs 1 --batch-size 8
+python src/train_dit.py data/cats --steps 100 --batch-size 8
+```
+
+> **Note:** See ADR-020 for the complete Modal CLI-First Training Strategy.
 
 ### train.py Changes
 ```python
@@ -130,7 +152,8 @@ Add new CLI arguments:
 
 ## Related
 - ADR-007: Modal GPU Training Fix
-- ADR-006: CI/CD Fix Workflow
+- ADR-017: TinyDiT Training Infrastructure
+- ADR-020: Modal CLI-First Training Strategy
 - GOAP.md: Modal Training phase
 - Modal GPU docs: https://modal.com/docs/guide/gpu
 

--- a/plans/ADR-017-tinydit-training-infrastructure.md
+++ b/plans/ADR-017-tinydit-training-infrastructure.md
@@ -91,17 +91,20 @@ TinyDiT(
 ```
 
 **Usage:**
+
+> **Note:** See ADR-020 for the complete Modal CLI-First Training Strategy.
+
 ```bash
 # Local training (debug)
-python src/train_dit.py data/cats --steps 1000
+python src/train_dit.py data/cats --steps 1000 --batch-size 8
 
-# Modal GPU training (production)
-modal run src/train_dit.py
+# Modal GPU training (production) - PRIMARY METHOD
+modal run src/train_dit.py data/cats
 
 # Resume from checkpoint
 python src/train_dit.py data/cats --resume checkpoints/dit_model.pt
 
-# Custom configuration
+# Custom configuration (Modal GPU)
 modal run src/train_dit.py -- \
   --steps 200000 \
   --batch-size 256 \
@@ -306,13 +309,22 @@ tiny-cats-model/
 | Mixed Precision | AMP (FP16) |
 
 ### Modal GPU Configuration
-| Setting | Value |
-|---------|-------|
-| GPU Type | A10G (or T4) |
-| Timeout | 7200s (2 hours) |
-| Volume | `/outputs`, `/data` |
-| Python | 3.12 |
-| Dependencies | torch, torchvision, Pillow, tqdm |
+
+| Setting | Value | Notes |
+|---------|-------|-------|
+| GPU Type | T4 (or A10G) | Configured via `@app.function(gpu="T4")` |
+| Timeout | 7200s (2 hours) | Sufficient for 200k steps |
+| Volume | `/outputs`, `/data` | Checkpoints and dataset |
+| Python | 3.10 | Via PyTorch base image |
+| Dependencies | torch, torchvision, Pillow, tqdm | Installed via `pip_install()` |
+
+**Execution:**
+```bash
+# Primary method: Modal CLI
+modal run src/train_dit.py data/cats --steps 200000
+
+# See ADR-020 for complete Modal CLI reference
+```
 
 ### Sampling Configuration
 | Parameter | Value |
@@ -345,12 +357,15 @@ python src/eval_dit.py --num-samples 2 --breed 0
 ```
 
 ### Modal GPU Testing
+
 ```bash
-# Test Modal GPU (1000 steps)
-modal run src/train_dit.py --steps 1000
+# Test Modal GPU (1000 steps) - PRIMARY METHOD
+modal run src/train_dit.py data/cats --steps 1000
 
 # Full training (200k steps)
-modal run src/train_dit.py --steps 200000
+modal run src/train_dit.py data/cats --steps 200000
+
+# See ADR-020 for complete Modal CLI reference
 ```
 
 ### Evaluation Testing
@@ -377,9 +392,9 @@ If you have existing checkpoints from `src/train.py` (ResNet classifier):
    bash data/download.sh
    ```
 
-2. **Train model**:
+2. **Train model** (Modal GPU - recommended):
    ```bash
-   modal run src/train_dit.py
+   modal run src/train_dit.py data/cats
    ```
 
 3. **Evaluate samples**:
@@ -390,6 +405,8 @@ If you have existing checkpoints from `src/train.py` (ResNet classifier):
 4. **Use in frontend**:
    - Models auto-deployed to `frontend/public/models/`
    - Generation page: `/generate`
+
+> **Note:** See ADR-020 for the complete Modal CLI-First Training Strategy and additional commands.
 
 ## References
 

--- a/plans/ADR-020-modal-cli-first-training-strategy.md
+++ b/plans/ADR-020-modal-cli-first-training-strategy.md
@@ -1,0 +1,401 @@
+# ADR-020: Modal CLI-First Training Strategy
+
+**Date:** 2026-02-25
+**Status:** Proposed
+**Authors:** AI Agent
+**Related:** ADR-007 (Modal GPU Training Fix), ADR-010 (Modal Training Improvements), ADR-011 (Modal Container Dependencies), ADR-017 (TinyDiT Training Infrastructure)
+
+## Context
+
+### Current State
+
+The codebase has two training scripts with Modal support:
+1. `src/train.py` - ResNet classifier training
+2. `src/train_dit.py` - TinyDiT training
+
+Both scripts use `@stub.function()` decorators for Modal integration. However, the `modal.yml` file suggests a YAML-based configuration approach, which is not Modal's recommended pattern.
+
+### Problem Statement
+
+The current `modal.yml` creates confusion about the training workflow:
+
+1. **YAML vs. Python Configuration**: Modal's modern approach uses Python decorators (`@app.function()`) directly in scripts, not YAML configuration files
+2. **Execution Model**: `modal.yml` is not executed directly - it was intended as documentation, but this is unclear
+3. **Inconsistent Documentation**: Some docs reference `modal.yml` while scripts use decorators
+4. **Limited Flexibility**: YAML configs are less flexible than Python for complex training logic
+
+### Modal's Recommended Pattern
+
+Modal's official documentation recommends:
+- Direct script execution with `modal run src/script.py`
+- Python decorators for configuration (`@app.function()`)
+- CLI arguments for runtime options
+- No YAML configuration file execution
+
+## Decision
+
+We will adopt a **Modal CLI-First Training Strategy**:
+
+### 1. Primary Training Interface
+
+All training will use the Modal CLI directly with Python scripts:
+
+```bash
+# Classifier training
+modal run src/train.py data/cats --epochs 20 --batch-size 64
+
+# DiT training
+modal run src/train_dit.py data/cats --steps 200000 --batch-size 256
+
+# With custom options
+modal run src/train.py -- --epochs 30 --lr 0.0001 --backbone resnet34
+modal run src/train_dit.py -- --steps 100000 --image-size 256
+```
+
+### 2. modal.yml as Documentation Reference
+
+The `modal.yml` file will be repurposed as **documentation only**:
+- Not executed by Modal
+- Serves as a quick reference for common commands
+- Contains environment setup reminders
+- Links to ADR-020 for full details
+
+### 3. Script Configuration via Decorators
+
+Both training scripts use Python decorators for Modal configuration:
+
+```python
+import modal
+
+app = modal.App("tiny-cats-model")
+
+@app.function(
+    image=modal.Image.from_registry("pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime")
+        .pip_install("torch", "torchvision", "pillow", "tqdm"),
+    gpu="T4",  # or "A10G" for faster training
+    timeout=7200,  # 2 hours
+    volumes={"/outputs": output_volume, "/data": data_volume},
+)
+def train_on_gpu(...):
+    # Training logic here
+    pass
+```
+
+### 4. Local Testing Support
+
+Scripts support both Modal GPU and local CPU execution:
+
+```bash
+# Local CPU testing (debug)
+python src/train.py data/cats --epochs 1 --batch-size 8
+python src/train_dit.py data/cats --steps 100
+
+# Modal GPU training (production)
+modal run src/train.py data/cats --epochs 20
+modal run src/train_dit.py data/cats --steps 200000
+```
+
+## Benefits
+
+### 1. Flexibility
+- **Python over YAML**: Full programming language for configuration
+- **Dynamic Configuration**: Conditional logic based on environment
+- **Type Safety**: Python type hints vs. untyped YAML
+- **IDE Support**: Autocomplete, linting, refactoring
+
+### 2. Better Debugging
+- **Local Execution**: Test locally before running on Modal
+- **Seamless Transition**: Same script runs locally or on GPU
+- **Direct Error Messages**: Python stack traces, not YAML parsing errors
+- **Interactive Development**: Use Python REPL for experimentation
+
+### 3. Modern Modal Pattern
+- **Official Recommendation**: Matches Modal's documented approach
+- **Community Standard**: Aligns with Modal examples and best practices
+- **Future-Proof**: Modal's development focus is on Python APIs
+
+### 4. Clearer Intent
+- **Self-Documenting**: Code shows exactly what happens
+- **No Ambiguity**: Scripts are executable, YAML is reference only
+- **Version Control**: Python changes are easier to review than YAML
+
+## Migration Guide
+
+### For Existing Users
+
+#### Before (Confusing)
+```bash
+# Unclear if modal.yml is used
+modal run src/train.py  # Does it read modal.yml?
+```
+
+#### After (Clear)
+```bash
+# Explicit: script runs on Modal GPU
+modal run src/train.py data/cats --epochs 20
+
+# Explicit: script runs locally on CPU
+python src/train.py data/cats --epochs 20
+```
+
+### Command Reference
+
+| Task | Command |
+|------|---------|
+| **Classifier Training** | |
+| Modal GPU (default) | `modal run src/train.py data/cats` |
+| Modal GPU (custom epochs) | `modal run src/train.py data/cats --epochs 30` |
+| Modal GPU (all options) | `modal run src/train.py -- --epochs 20 --batch-size 64 --backbone resnet34` |
+| Local CPU (debug) | `python src/train.py data/cats --epochs 1 --batch-size 8` |
+| **DiT Training** | |
+| Modal GPU (default) | `modal run src/train_dit.py data/cats` |
+| Modal GPU (custom steps) | `modal run src/train_dit.py data/cats --steps 100000` |
+| Modal GPU (all options) | `modal run src/train_dit.py -- --steps 200000 --batch-size 256 --lr 0.0001` |
+| Local CPU (debug) | `python src/train_dit.py data/cats --steps 100 --batch-size 8` |
+| **Authentication** | |
+| Setup Modal tokens | `modal token set` |
+| Check status | `modal app list` |
+
+### Environment Setup
+
+```bash
+# 1. Install Modal CLI
+pip install modal
+
+# 2. Authenticate (one-time)
+modal token set
+
+# 3. Install project dependencies
+pip install -r requirements.txt
+
+# 4. Download dataset
+bash data/download.sh
+
+# 5. Train on Modal GPU
+modal run src/train.py data/cats --epochs 20
+```
+
+## Implementation Details
+
+### Script Structure
+
+Both training scripts follow this pattern:
+
+```python
+"""Docstring with usage examples."""
+
+import argparse
+import modal
+
+# Modal app definition
+app = modal.App("tiny-cats-model")
+
+# GPU function with decorator configuration
+@app.function(
+    image=modal.Image.from_registry("pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime")
+        .pip_install_from_requirements("requirements.txt"),
+    gpu="T4",
+    timeout=7200,
+    volumes={"/outputs": output_volume},
+)
+def train_on_gpu(data_dir: str, **kwargs):
+    """Training logic runs on Modal GPU."""
+    # ... training code ...
+    pass
+
+# Local entry point
+@app.local_entrypoint()
+def main(
+    data_dir: str = "data/cats",
+    epochs: int = 20,
+    batch_size: int = 64,
+):
+    """CLI entry point - runs locally, calls GPU function."""
+    train_on_gpu.remote(data_dir, epochs=epochs, batch_size=batch_size)
+```
+
+### CLI Argument Passing
+
+Modal CLI passes arguments to scripts:
+
+```bash
+# Arguments after -- go to the script
+modal run src/train.py -- --epochs 20 --batch-size 64
+
+# Or positional arguments directly
+modal run src/train.py data/cats
+```
+
+### Volume Mounting
+
+```python
+# Create or reference volumes
+output_volume = modal.Volume.from_name("cats-model-outputs", create_if_missing=True)
+data_volume = modal.Volume.from_name("cats-dataset", create_if_missing=True)
+
+# Mount in function decorator
+@app.function(volumes={"/outputs": output_volume, "/data": data_volume})
+```
+
+## Consequences
+
+### Positive
+- ✅ **Clear Workflow**: `modal run` = GPU, `python` = CPU
+- ✅ **Better Documentation**: Scripts are self-documenting
+- ✅ **Easier Maintenance**: Python is easier to maintain than YAML + Python
+- ✅ **Modern Pattern**: Aligns with Modal's direction
+- ✅ **Flexible Configuration**: Python enables complex logic
+
+### Negative
+- ⚠️ **Documentation Update**: Need to update all references to modal.yml
+- ⚠️ **Learning Curve**: Users unfamiliar with Modal CLI need guidance
+- ⚠️ **Legacy Confusion**: Old docs may reference modal.yml as executable
+
+### Neutral
+- ℹ️ **modal.yml Retained**: Kept as documentation reference, not deleted
+- ℹ️ **Same Functionality**: Training behavior unchanged, only interface clarified
+
+## Alternatives Considered
+
+### Alternative 1: Keep modal.yml as Executable Config
+**Proposal**: Use modal.yml with `modal deploy` or similar.
+
+**Rejected Because**:
+- Modal's modern approach is Python-first
+- YAML is less expressive than Python
+- Doesn't match Modal's official examples
+- Limited flexibility for complex training logic
+
+### Alternative 2: Hybrid Approach (YAML + Python)
+**Proposal**: Use modal.yml for simple config, Python for complex logic.
+
+**Rejected Because**:
+- Two sources of truth creates confusion
+- Debugging becomes harder (which config is used?)
+- Modal doesn't officially support this pattern
+- More documentation overhead
+
+### Alternative 3: Pure Python (No modal.yml)
+**Proposal**: Delete modal.yml entirely, use only Python.
+
+**Rejected Because**:
+- modal.yml is useful as quick reference
+- Helps users discover common commands
+- Serves as documentation anchor
+- Low maintenance cost if marked as reference-only
+
+## Technical Specifications
+
+### Modal CLI Commands
+
+```bash
+# Authentication
+modal token set                    # Configure tokens
+modal token list                   # Show configured tokens
+
+# App Management
+modal app list                     # List deployed apps
+modal app stop tiny-cats-model     # Stop running app
+
+# Training
+modal run src/train.py             # Run classifier training
+modal run src/train_dit.py         # Run DiT training
+modal shell src/train.py           # Open shell in container
+
+# Volume Management
+modal volume ls cats-model-outputs # List volume contents
+modal volume get cats-model-outputs /outputs/model.pt ./model.pt  # Download
+
+# Monitoring
+modal app logs tiny-cats-model     # View logs
+```
+
+### Script Configuration Options
+
+#### Classifier (src/train.py)
+| Option | Default | Description |
+|--------|---------|-------------|
+| `data_dir` | `data/cats` | Dataset path |
+| `--epochs` | `10` | Training epochs |
+| `--batch-size` | `32` | Batch size |
+| `--lr` | `1e-4` | Learning rate |
+| `--backbone` | `resnet18` | Model backbone |
+| `--mixed-precision` | `True` | Enable AMP |
+| `--gradient-clip` | `1.0` | Gradient clipping norm |
+
+#### DiT (src/train_dit.py)
+| Option | Default | Description |
+|--------|---------|-------------|
+| `data_dir` | `data/cats` | Dataset path |
+| `--steps` | `200000` | Training steps |
+| `--batch-size` | `256` | Batch size |
+| `--lr` | `1e-4` | Learning rate |
+| `--image-size` | `128` | Output image size |
+| `--warmup-steps` | `10000` | LR warmup steps |
+| `--ema-beta` | `0.9999` | EMA decay rate |
+| `--resume` | `None` | Checkpoint to resume |
+
+### GPU Configuration
+
+| GPU Type | Cost/Hour | Use Case |
+|----------|-----------|----------|
+| `T4` | ~$0.35 | Standard training, cost-effective |
+| `A10G` | ~$1.00 | Faster training, larger models |
+| `A100` | ~$3.00 | Large-scale training (if needed) |
+
+Configure in script:
+```python
+@app.function(gpu="T4")  # or "A10G", "A100", "H100"
+```
+
+## Success Metrics
+
+- [x] ADR-020 created and documented
+- [ ] modal.yml updated to documentation-only
+- [ ] GOAP.md updated with CLI commands
+- [ ] ADR-017 updated with CLI emphasis
+- [ ] ADR-010 status → Implemented
+- [ ] AGENTS.md updated with CLI commands
+- [ ] All training uses Modal CLI consistently
+
+## References
+
+- Modal Documentation: https://modal.com/docs
+- Modal GPU Guide: https://modal.com/docs/guide/gpu
+- Modal CLI Reference: https://modal.com/docs/reference/cli
+- ADR-007: Modal GPU Training Fix
+- ADR-010: Modal Training Improvements
+- ADR-017: TinyDiT Training Infrastructure
+
+## Appendix: Example Training Session
+
+```bash
+# 1. Setup (one-time)
+$ modal token set
+Token set successfully.
+
+# 2. Download dataset
+$ bash data/download.sh
+Downloading Oxford IIIT Pet dataset...
+Dataset ready at data/cats/
+
+# 3. Test locally (CPU)
+$ python src/train.py data/cats --epochs 1 --batch-size 8
+2026-02-25 10:00:00 | INFO     | Starting training...
+2026-02-25 10:05:00 | INFO     | Epoch 1/1 complete. Loss: 1.234
+Training complete!
+
+# 4. Train on Modal GPU
+$ modal run src/train.py data/cats --epochs 20
+🔨 Running src/train.py
+⠦ Building image...
+⠦ Pulling code...
+⠦ Running training...
+2026-02-25 10:30:00 | INFO     | Starting training on GPU (T4)...
+2026-02-25 11:30:00 | INFO     | Epoch 20/20 complete. Loss: 0.234
+✅ Training complete! Model saved to /outputs/cats_model.pt
+
+# 5. Download model
+$ modal volume get cats-model-outputs /outputs/cats_model.pt ./cats_model.pt
+Downloaded 45.2 MB
+```

--- a/plans/GOAP.md
+++ b/plans/GOAP.md
@@ -210,6 +210,28 @@ Build a cats classifier and generator with web frontend, following the architect
 | EMA Beta | 0.9999 |
 | Loss | Flow matching (v or x prediction) |
 
+### Training Commands (Modal CLI)
+
+**Classifier Training:**
+```bash
+# Modal GPU training (recommended)
+modal run src/train.py data/cats --epochs 20 --batch-size 64
+
+# Local CPU testing (debug)
+python src/train.py data/cats --epochs 1 --batch-size 8
+```
+
+**DiT Training:**
+```bash
+# Modal GPU training (recommended)
+modal run src/train_dit.py data/cats --steps 200000 --batch-size 256
+
+# Local CPU testing (debug)
+python src/train_dit.py data/cats --steps 100 --batch-size 8
+```
+
+See ADR-020 for complete Modal CLI reference.
+
 ### Frontend Stack
 - **Framework**: React 18 + TypeScript
 - **Build Tool**: Vite


### PR DESCRIPTION
## Summary

This PR introduces the **Modal CLI-First Training Strategy** (ADR-020), standardizing all training workflows to use Modal CLI directly with Python scripts.

## Changes

### 1. ADR-020 (New)
**Title**: Modal CLI-First Training Strategy

Documents the decision to use `modal run src/*.py` as the primary training interface instead of YAML-based configuration.

**Benefits**:
- ✅ Follows Modal's recommended pattern
- ✅ Python decorators provide better flexibility than YAML
- ✅ Type-safe with IDE support
- ✅ Easier debugging (run locally or on Modal)
- ✅ Clearer separation of concerns

### 2. modal.yml Repurposed
- Changed from executable config → **documentation reference only**
- Added prominent warning: "⚠️ NOT executed directly by Modal"
- Organized as quick reference for common CLI commands
- Links to ADR-020 for complete guidance

### 3. Documentation Updates
| File | Changes |
|------|---------|
| GOAP.md | Added "Training Commands (Modal CLI)" section |
| ADR-017 | Updated usage to emphasize Modal CLI as primary method |
| ADR-010 | Status → Implemented, added CLI references |
| AGENTS.md | Updated Quick Commands and Modal GPU Training sections |

## Training Commands (Modal CLI)

### Classifier Training
```bash
modal run src/train.py data/cats --epochs 20 --batch-size 64
```

### DiT Training
```bash
modal run src/train_dit.py data/cats --steps 200000 --batch-size 256
```

### Local Testing (CPU)
```bash
python src/train.py data/cats --epochs 1 --batch-size 8
python src/train_dit.py data/cats --steps 100 --batch-size 8
```

## Related

- ADR-020: Modal CLI-First Training Strategy (new)
- ADR-007: Modal GPU Training Fix
- ADR-010: Modal Training Improvements
- ADR-017: TinyDiT Training Infrastructure