### PR TITLE
fix: correct node cache path in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "frontend/node_modules"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
 
       - name: Install dependencies
         working-directory: ./frontend


### PR DESCRIPTION
## Summary
- Fix node_modules cache path in deploy.yml (was using wrong path)
- Uses npm cache with correct package-lock.json path