### PR TITLE
feat: add HF Hub upload and WebGPU inference

### DIFF
--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -11,6 +11,12 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      skip_training:
+        description: "Skip Modal training (for testing CI only)"
+        required: false
+        default: "false"
+        type: boolean
 
 # 2026 Best Practice: Smart concurrency
 concurrency:
@@ -107,4 +113,108 @@ jobs:
           from dataset import build_transforms, get_class_names
           t = build_transforms(train=True)
           print(f'Transforms OK: {t}')
+          "
+
+  train-classifier:
+    name: Train Classifier (Modal)
+    needs: [lint, test, model-import-check]
+    if: github.event_name == 'workflow_dispatch' && !inputs.skip_training
+    runs-on: ubuntu-latest
+    environment:
+      name: modal-training
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Modal
+        run: pip install modal
+
+      - name: Run training
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: modal run src/train.py data/cats
+
+      - name: Download ONNX from Modal
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: |
+          pip install modal
+          modal volume get cats-model-outputs /outputs/cats_classifier.onnx ./cats_classifier.onnx
+
+      - name: Upload to Hugging Face Hub
+        if: vars.HF_TOKEN != ''
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          pip install huggingface_hub
+          python -c "
+          from huggingface_hub import HfApi
+          api = HfApi()
+          api.upload_file(
+              path_or_fileobj='cats_classifier.onnx',
+              path_in_repo='cats_classifier.onnx',
+              repo_id='d4oit/tiny-cats-model',
+              repo_type='model',
+              commit_message='Upload classifier from GitHub Actions'
+          )
+          print('Classifier uploaded to HF Hub')
+          "
+
+  train-dit:
+    name: Train DiT (Modal)
+    needs: [lint, test, model-import-check]
+    if: github.event_name == 'workflow_dispatch' && !inputs.skip_training
+    runs-on: ubuntu-latest
+    environment:
+      name: modal-training
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Modal
+        run: pip install modal
+
+      - name: Run DiT training
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: modal run src/train_dit.py data/cats
+
+      - name: Download ONNX from Modal
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: |
+          pip install modal
+          modal volume get dit-outputs /outputs/cats_dit.onnx ./cats_dit.onnx
+
+      - name: Upload to Hugging Face Hub
+        if: vars.HF_TOKEN != ''
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          pip install huggingface_hub
+          python -c "
+          from huggingface_hub import HfApi
+          api = HfApi()
+          api.upload_file(
+              path_or_fileobj='cats_dit.onnx',
+              path_in_repo='cats_dit.onnx',
+              repo_id='d4oit/tiny-cats-model',
+              repo_type='model',
+              commit_message='Upload DiT from GitHub Actions'
+          )
+          print('DiT uploaded to HF Hub')
           "

--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -4,6 +4,8 @@
 # ADR-016: Modern Python Code Quality (Ruff only)
 
 name: Train
+permissions:
+  contents: read
 
 on:
   push:

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -17,7 +17,7 @@ export interface ModelConfig {
 
 export const MODEL_CONFIGS: Record<ModelType, ModelConfig> = {
   cats: {
-    modelPath: "/tiny-cats-model/models/cats_quantized.onnx",
+    modelPath: "https://huggingface.co/d4oit/tiny-cats-model/resolve/main/cats_classifier.onnx",
     imgDims: [224, 224],
     numClasses: 2,
     classNames: ["cat", "not_cat"],
@@ -55,7 +55,7 @@ export interface GeneratorConfig {
 }
 
 export const GENERATOR_CONFIG: GeneratorConfig = {
-  modelPath: "/tiny-cats-model/models/generator.onnx",
+  modelPath: "https://huggingface.co/d4oit/tiny-cats-model/resolve/main/cats_dit.onnx",
   imgDims: [128, 128],
   numBreeds: 13,
   defaultSteps: 50,

--- a/frontend/src/engine/inference.worker.ts
+++ b/frontend/src/engine/inference.worker.ts
@@ -5,6 +5,29 @@ import { MODEL_CONFIGS, type ModelConfig, type ModelType } from "../constants";
 
 ort.env.wasm.wasmPaths = "/tiny-cats-model/";
 
+async function getExecutionProvider(): Promise<["wasm"] | ["webgpu"]> {
+  if (typeof navigator !== "undefined") {
+    try {
+      const gpu = await navigator.gpu;
+      if (gpu) {
+        return ["webgpu"];
+      }
+    } catch {
+      // WebGPU not available
+    }
+  }
+  return ["wasm"];
+}
+
+async function loadOrt(): Promise<typeof ort> {
+  const ep = await getExecutionProvider();
+  if (ep[0] === "webgpu") {
+    const ortWebGpu = await import("onnxruntime-web/webgpu");
+    return ortWebGpu as unknown as typeof ort;
+  }
+  return ort;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 if (typeof navigator !== "undefined" && (self as any).crossOriginIsolated) {
   ort.env.wasm.numThreads = navigator.hardwareConcurrency || 2;
@@ -13,6 +36,8 @@ if (typeof navigator !== "undefined" && (self as any).crossOriginIsolated) {
 }
 
 ort.env.wasm.proxy = false;
+
+let ortInstance: typeof ort | null = null;
 
 export interface ClassificationResult {
   classIndex: number;
@@ -30,12 +55,17 @@ class InferenceEngine {
   session: ort.InferenceSession | null = null;
   modelType: string = "";
   configs: ModelConfig | null = null;
+  executionProvider: "wasm" | "webgpu" = "wasm";
 
   async loadModel(path: string, modelType: ModelType) {
     console.log("Loading model...");
     try {
       this.modelType = modelType;
       this.configs = MODEL_CONFIGS[modelType];
+
+      ortInstance = await loadOrt();
+      this.executionProvider = (await getExecutionProvider())[0];
+      console.log("Using execution provider:", this.executionProvider);
 
       console.log("Fetching model from:", path);
       const response = await fetch(path, { mode: "cors", credentials: "omit" });
@@ -47,8 +77,8 @@ class InferenceEngine {
 
       console.log("Creating inference session...");
 
-      this.session = await ort.InferenceSession.create(modelDataUint8, {
-        executionProviders: ["wasm"],
+      this.session = await ortInstance.InferenceSession.create(modelDataUint8, {
+        executionProviders: [this.executionProvider],
         graphOptimizationLevel: "all"
       });
 
@@ -64,11 +94,12 @@ class InferenceEngine {
   async classify(imageTensor: Float32Array): Promise<ClassificationTelemetry> {
     if (!this.session) throw new Error("Model not loaded");
     if (!this.configs) throw new Error("Model config not loaded");
+    if (!ortInstance) throw new Error("ORT not loaded");
 
     const [height, width] = this.configs.imgDims;
     const inputDims = [1, 3, height, width];
 
-    const inputTensor = new ort.Tensor("float32", imageTensor, inputDims);
+    const inputTensor = new ortInstance.Tensor("float32", imageTensor, inputDims);
 
     const result = await this.session.run({
       input: inputTensor


### PR DESCRIPTION
## Summary
- Update model URLs to HuggingFace CDN (d4oit/tiny-cats-model)
- Add WebGPU detection with WASM fallback in inference worker  
- Add auto-upload to HF Hub after Modal training in train.yml

## Usage
1. Set `HF_TOKEN` secret: `gh secret set HF_TOKEN`
2. Trigger training: `gh workflow run train.yml`
3. Models auto-upload to HF Hub after training completes