### PR TITLE
fix(ADR-051): Use absolute path /data/cats for Modal volume mount

### DIFF
--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -262,7 +262,7 @@ jobs:
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
           modal run src/train_dit.py \
-            --data-dir data/cats \
+            --data-dir /data/cats \
             --steps ${{ github.event.inputs.steps || '400000' }} \
             --batch-size ${{ github.event.inputs.batch_size || '256' }} \
             --lr ${{ github.event.inputs.lr || '5e-5' }} \

--- a/agents-docs/learnings.md
+++ b/agents-docs/learnings.md
@@ -80,13 +80,54 @@ After each task, capture learnings here. Use this for continuous improvement.
 - ADR-048: Modal CLI Syntax Fix
 - ADR-046: GitHub Actions Missing Dependencies Fix  
 - ADR-050: train_dit.py Argument Parser Fix
+- ADR-051: Modal Volume Path Mismatch Fix
 - train.yml: Fixed CLI syntax and added dependency installation
 - src/train_dit.py: Changed data_dir from positional to --data-dir flag
 - agents-docs/learnings.md: This entry
 
 ---
 
-### fix: Modal Container Import Path & ExperimentTracker (February 2026)
+### fix: Modal Volume Path Mismatch (March 2026)
+
+**Date**: 2026-03-03
+**Type**: bug fix
+**Areas**: modal, volumes, github actions
+**Related**: ADR-051, train.yml, ADR-024
+
+**What worked**:
+- Using absolute paths `/data/cats` to match Modal volume mount points
+- Clear understanding of Modal container filesystem layout
+
+**Issues encountered**:
+- Dataset download succeeded but training couldn't find `data/cats`
+- Path mismatch: relative `data/cats` vs absolute `/data/cats`
+
+**Root Cause Analysis**:
+| Issue | Root Cause | Impact |
+|-------|------------|--------|
+| No such file or directory | Used relative path `data/cats` instead of absolute `/data/cats` | Training fails after download |
+| Volume mount mismatch | Modal mounts volume at `/data` but script looked in `/app/data` | Dataset not accessible |
+
+**Fix applied**:
+Changed train.yml to use absolute path:
+```yaml
+# WRONG:
+--data-dir data/cats
+
+# CORRECT:
+--data-dir /data/cats
+```
+
+**Pattern extracted**:
+- **Modal Volume Paths**: Always use absolute paths matching volume mounts
+- **Container vs Local**: Local uses `data/cats`, Modal container uses `/data/cats`
+- **Volume Configuration**: Review `@app.function(volumes={...})` to understand mount points
+
+**Documentation updated**:
+- ADR-051: Modal Volume Path Mismatch Fix
+- train.yml: Updated to use `/data/cats`
+
+---
 
 **Date**: 2026-02-28
 **Type**: bug fix

--- a/plans/ADR-051-modal-volume-path-mismatch.md
+++ b/plans/ADR-051-modal-volume-path-mismatch.md
@@ -1,0 +1,70 @@
+# ADR-051: Modal Volume Path Mismatch Fix
+
+## Status
+Accepted
+
+## Context
+After fixing ADR-050 (train_dit.py CLI argument), the training job started successfully but failed immediately with:
+
+```
+2026-03-03 08:56:40 | ERROR    | Training failed: [Errno 2] No such file or directory: 'data/cats'
+```
+
+The Modal volumes are configured as:
+```python
+@app.function(
+    volumes={
+        "/outputs": volume_outputs,
+        "/data": volume_data,
+    },
+)
+```
+
+This means:
+- Data volume is mounted at `/data` in the container
+- Dataset should be at `/data/cats` (absolute path)
+- But the CLI was passing `data/cats` which resolves to `/app/data/cats` (relative to working directory)
+
+## Decision
+Use absolute path `/data/cats` in the GitHub Actions workflow to match the Modal volume mount point.
+
+## Changes
+
+### train.yml
+Changed from:
+```yaml
+run: |
+  modal run src/train_dit.py \
+    --data-dir data/cats \
+    ...
+```
+
+To:
+```yaml
+run: |
+  modal run src/train_dit.py \
+    --data-dir /data/cats \
+    ...
+```
+
+## Consequences
+
+**Positive:**
+- Dataset path now correctly resolves to the volume mount point
+- Training can access cached dataset from previous runs
+- Consistent with Modal volume configuration
+
+**Negative:**
+- Absolute paths are less portable across environments
+- Local testing requires different path (`data/cats` vs `/data/cats`)
+
+## Alternatives Considered
+
+1. **Change container working directory**: Change `os.chdir("/app")` to `os.chdir("/data")` - rejected because it breaks other relative paths
+2. **Use environment variable**: Set `DATA_DIR` env var - rejected as overkill for single path
+3. **Add path mapping logic in script**: Auto-convert relative to absolute - rejected as magic/hidden behavior
+
+## Related
+- ADR-024: Modal Volume Storage Organization
+- ADR-031: Modal Container Download Scripts Fix
+- ADR-050: train_dit.py CLI Argument Fix


### PR DESCRIPTION
## Summary
Fixes dataset path mismatch in Modal training. The volume is mounted at `/data` but the workflow was using relative path `data/cats` which resolved to `/app/data/cats`.

## Changes
- Changed `--data-dir data/cats` to `--data-dir /data/cats` in train.yml

## Testing
- Matches Modal volume configuration: `/data: volume_data`
- Dataset will be accessible at correct absolute path

## Related
- ADR-051: Modal Volume Path Mismatch Fix
- ADR-024: Modal Volume Storage Organization