### PR TITLE
fix(ADR-052): Add missing Modal container imports to train.py

### DIFF
--- a/plans/ADR-052-modal-container-missing-imports.md
+++ b/plans/ADR-052-modal-container-missing-imports.md
@@ -1,0 +1,73 @@
+# ADR-052: Fix Modal Container Missing Module Imports in train.py
+
+## Status
+Accepted
+
+## Context
+The 400k training job (Run 22620541362) failed with:
+```
+ModuleNotFoundError: No module named 'auth_utils'
+```
+
+The error occurred because `train.py`:
+1. Had direct imports without fallback handling for `auth_utils` and `experiment_tracker`
+2. Missing `add_local_file` entries in Modal container image configuration
+
+While `train_dit.py` had proper try/except fallback pattern and complete `add_local_file` entries (ADR-042), `train.py` was not updated with the same pattern.
+
+## Root Cause Analysis
+
+| Component | train.py | train_dit.py |
+|-----------|----------|--------------|
+| Import pattern | Direct import | try/except fallback ✅ |
+| auth_utils in container | ❌ Missing | ✅ Added (ADR-042) |
+| retry_utils in container | ❌ Missing | ✅ Added (ADR-042) |
+| experiment_tracker in container | ❌ Missing | ✅ Added (ADR-042) |
+
+## Decision
+1. Add try/except fallback pattern for optional imports (matching `train_dit.py`)
+2. Add missing `add_local_file` entries for `auth_utils.py`, `retry_utils.py`, `experiment_tracker.py`
+
+## Changes
+
+### src/train.py
+```python
+# BEFORE: Direct imports (breaks if module not in container)
+from auth_utils import AuthenticationError, require_modal_auth, setup_auth_logging
+from experiment_tracker import ExperimentTracker
+
+# AFTER: Try/except with fallbacks
+try:
+    from auth_utils import AuthenticationError, require_modal_auth, setup_auth_logging
+    AUTH_UTILS_AVAILABLE = True
+except ImportError:
+    AUTH_UTILS_AVAILABLE = False
+    # Fallback classes defined...
+```
+
+### Modal container configuration
+```python
+# Added to image.add_local_file():
+.add_local_file("src/auth_utils.py", "/app/auth_utils.py")
+.add_local_file("src/retry_utils.py", "/app/retry_utils.py")
+.add_local_file("src/experiment_tracker.py", "/app/experiment_tracker.py")
+```
+
+## Consequences
+
+**Positive:**
+- Training scripts have consistent import patterns
+- Both `train.py` and `train_dit.py` work correctly in Modal container
+- Graceful degradation when optional modules unavailable
+
+**Negative:**
+- Slightly more complex import logic
+- Must maintain fallback classes in sync with actual implementations
+
+## Related
+- ADR-042: Modal Training Enhancement (original fix for train_dit.py)
+- ADR-030: Modal Container Python Path Fix
+- ADR-031: Modal Container Download Scripts Fix
+
+## Date
+2026-03-03

--- a/src/train.py
+++ b/src/train.py
@@ -42,8 +42,56 @@ import torch.nn as nn
 from torch.optim import Adam
 from torch.optim.lr_scheduler import CosineAnnealingLR, LinearLR, SequentialLR
 
-from auth_utils import AuthenticationError, require_modal_auth, setup_auth_logging
-from experiment_tracker import ExperimentTracker
+# Optional auth utilities import (for enhanced error handling)
+try:
+    from auth_utils import AuthenticationError, require_modal_auth, setup_auth_logging
+
+    AUTH_UTILS_AVAILABLE = True
+except ImportError:
+    AUTH_UTILS_AVAILABLE = False
+
+    # Fallback for Modal container
+    class AuthenticationError(Exception):  # type: ignore
+        pass
+
+    def require_modal_auth():  # type: ignore
+        pass
+
+    def setup_auth_logging(level=None):  # type: ignore
+        import logging
+
+        return logging.getLogger("cats_classifier")
+
+
+# Optional experiment tracker import
+try:
+    from experiment_tracker import ExperimentTracker
+except ImportError:
+    # Fallback simple tracker (ADR-042)
+    class ExperimentTracker:  # type: ignore[no-redef]
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start_run(self, *args, **kwargs):
+            return None
+
+        def log_params(self, *args, **kwargs):
+            pass
+
+        def log_metrics(self, *args, **kwargs):
+            pass
+
+        def log_model(self, *args, **kwargs):
+            pass
+
+        def log_artifact(self, *args, **kwargs):
+            pass
+
+        def end_run(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            pass
 
 
 # Configure logging
@@ -368,6 +416,9 @@ image = (
     .add_local_file("src/dataset.py", "/app/dataset.py")
     .add_local_file("src/model.py", "/app/model.py")
     .add_local_file("src/volume_utils.py", "/app/volume_utils.py")
+    .add_local_file("src/auth_utils.py", "/app/auth_utils.py")
+    .add_local_file("src/retry_utils.py", "/app/retry_utils.py")
+    .add_local_file("src/experiment_tracker.py", "/app/experiment_tracker.py")
     .add_local_file("data/download.py", "/app/data/download.py")
     .add_local_file("data/download.sh", "/app/data/download.sh")
 )


### PR DESCRIPTION
## Summary
- Add try/except fallback pattern for `auth_utils` and `experiment_tracker` imports
- Add missing `add_local_file` entries for `auth_utils.py`, `retry_utils.py`, `experiment_tracker.py`
- Match `train_dit.py` import pattern (ADR-042)

## Root Cause
The 400k training job failed with `ModuleNotFoundError: No module named 'auth_utils'` because `train.py` had direct imports without fallback handling and was missing the Modal container file entries.

## Test Plan
- [ ] CI pipeline passes
- [ ] Train workflow starts successfully
- [ ] Modal container builds without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)