### PR TITLE
Fix: Remove invalid --timeout-minutes from classifier training

### DIFF
--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -165,11 +165,9 @@ jobs:
         env:
           MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
-          MODAL_TIMEOUT_MINUTES: 120
         run: |
           modal run src/train.py \
-            --data-dir data/cats \
-            --timeout-minutes ${MODAL_TIMEOUT_MINUTES:-120}
+            --data-dir data/cats
 
       - name: Download ONNX from Modal
         env:

--- a/plans/ADR-053-modal-github-actions-timeout-fix.md
+++ b/plans/ADR-053-modal-github-actions-timeout-fix.md
@@ -80,6 +80,8 @@ train-classifier:
 
 **Rationale:** Classifier training is fast (~30-60 minutes), 3 hours provides buffer.
 
+**Note:** The `train.py` script uses Modal's `@app.function(timeout=...)` decorator for timeout control (see `src/train.py` line ~420), not CLI arguments. Do NOT pass `--timeout-minutes` to `modal run src/train.py`.
+
 #### 2. Train DiT (Modal)
 ```yaml
 train-dit:


### PR DESCRIPTION
## Problem

train.py doesn't accept `--timeout-minutes` CLI argument.

## Solution

Remove the invalid flag. Modal timeout is controlled by `@app.function(timeout=3600)` decorator (1 hour), not CLI args.

## Changes

- `train.yml`: Removed `--timeout-minutes` from classifier training step
- ADR-053: Updated documentation noting timeout is in Modal decorator

## Status

- DiT training: ✅ Running (uses correct Modal timeout decorator)
- Classifier: ❌ Failing (exit 2 - invalid option)

After this fix, classifier should run successfully.