### PR TITLE
fix: classifier training data directory path (ADR-054)

### DIFF
--- a/.github/workflows/train.yml
+++ b/.github/workflows/train.yml
@@ -15,7 +15,7 @@ on:
       skip_training:
         description: "Skip Modal training (for testing CI only)"
         required: false
-        default: "false"
+        default: false
         type: boolean
       steps:
         description: "Training steps (default: 100k with early stopping)"
@@ -172,7 +172,7 @@ jobs:
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
           modal run src/train.py \
-            --data-dir data/cats
+            --data-dir /data/cats
 
       - name: Download ONNX from Modal
         env:

--- a/plans/ADR-054-classifier-training-data-path-fix.md
+++ b/plans/ADR-054-classifier-training-data-path-fix.md
@@ -1,0 +1,52 @@
+# ADR-054: Fix Classifier Training Data Directory Path
+
+## Status
+Accepted
+
+## Context
+GitHub Actions workflow for classifier training was failing with:
+```
+DataLoadError: Dataset directory not found: data/cats
+```
+
+The error occurred because:
+1. The workflow passed `--data-dir data/cats` (relative path)
+2. Modal container downloads dataset to `/data/cats` (absolute path in volume)
+3. The `train_on_gpu` function received `data/cats` but the dataset was at `/data/cats`
+
+## Root Cause Analysis
+
+The Modal container setup:
+- Volume `cats-dataset` is mounted at `/data`
+- Dataset download script (`data/download.py`) respects `CATS_DIR` env var, defaulting to `/data/cats`
+- The training function `train_on_gpu` has default `data_dir="/data/cats"`
+
+But the GitHub Actions workflow was passing:
+```yaml
+modal run src/train.py --data-dir data/cats
+```
+
+This overrode the correct default with a relative path that doesn't exist in the container.
+
+## Decision
+
+Change the workflow to use the correct absolute path:
+```yaml
+modal run src/train.py --data-dir /data/cats
+```
+
+This aligns with:
+- The DiT training workflow which already uses `--data-dir /data/cats`
+- The Modal volume mount at `/data`
+- The dataset download location
+
+## Consequences
+
+- Classifier training will now find the dataset correctly
+- Consistent path handling between classifier and DiT training workflows
+- Dataset caching in Modal volumes will work properly
+
+## References
+- ADR-024: Modal Volume Storage
+- ADR-031: Modal Container Download Scripts Fix
+- Error log: https://github.com/d-oit/tiny-cats-model/actions/runs/22680614728

--- a/plans/GOAP.md
+++ b/plans/GOAP.md
@@ -595,6 +595,28 @@ bash scripts/train_dit_high_accuracy.sh --local  # 4000 steps, ~5-10 min
 **Progress:** 6/7 actions complete (86%)
 **Blocker:** None - Workflow ready for testing (requires HF_TOKEN)
 
+### Phase 22.5: Classifier Training Data Path Fix (ADR-054)
+
+**Issue:** Classifier training failed with `DataLoadError: Dataset directory not found: data/cats`
+**Root Cause:** GitHub Actions workflow passed relative path `data/cats` but Modal container expects absolute `/data/cats`
+**Fix:** Changed workflow to use absolute path `/data/cats` matching Modal volume mount
+
+#### Completed Actions
+- [x] Create ADR-054: Classifier Training Data Path Fix
+- [x] Update .github/workflows/train.yml - Changed `--data-dir data/cats` to `--data-dir /data/cats`
+- [x] Fix YAML boolean default type (string `"false"` → boolean `false`)
+- [x] Create PR #40 for the fix
+- [x] Push to branch fix/modal-timeout-adr-053
+
+#### GOAP Action Status for Phase 22.5
+| Action | Status | Phase | Skill | Completed At | Notes |
+|--------|--------|-------|-------|--------------|-------|
+| A01: Create ADR-054 | ✅ Complete | 22.5 | goap | 2026-03-04 | Data path fix documented |
+| A02: Fix workflow | ✅ Complete | 22.5 | gh-actions | 2026-03-04 | data/cats → /data/cats |
+| A03: Fix YAML type | ✅ Complete | 22.5 | gh-actions | 2026-03-04 | "false" → false |
+| A04: Create PR #40 | ✅ Complete | 22.5 | git-workflow | 2026-03-04 | PR created and CI running |
+| A05: Merge PR | 🔄 PENDING | 22.5 | git-workflow | - | Waiting for CI checks |
+
 ### Phase 22: Authentication Utilities (ADR-045)
 
 **Goal:** Implement robust authentication validation and retry utilities (GOAP-AUTH-PLAN A01-A04).


### PR DESCRIPTION
## Summary
- Fix classifier training `--data-dir` from relative `data/cats` to absolute `/data/cats`
- Fix YAML boolean default type (string `"false"` → boolean `false`)

## Problem
The Modal container has the dataset volume mounted at `/data`, so the dataset is at `/data/cats`. The workflow was passing `--data-dir data/cats` (relative path) which caused:
```
DataLoadError: Dataset directory not found: data/cats
```

## Solution
Use the absolute path `/data/cats` which matches the Modal volume mount.

## Test plan
- [ ] Trigger classifier training via workflow_dispatch
- [ ] Verify dataset is found and training starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)